### PR TITLE
Add accessible tabs component

### DIFF
--- a/_src/assets/js/_tabs.js
+++ b/_src/assets/js/_tabs.js
@@ -1,0 +1,99 @@
+const setInitialState = (tab, panel, isSelected) => {
+  tab.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+  tab.tabIndex = isSelected ? 0 : -1;
+  tab.classList.toggle('is-active', isSelected);
+
+  if (panel) {
+    panel.setAttribute('role', 'tabpanel');
+    panel.setAttribute('aria-labelledby', tab.id);
+    panel.tabIndex = 0;
+
+    if (isSelected) {
+      panel.removeAttribute('hidden');
+    } else {
+      panel.setAttribute('hidden', '');
+    }
+  }
+};
+
+const activateTab = (tab, tabs, panels) => {
+  tabs.forEach((currentTab, index) => {
+    const panelId = currentTab.getAttribute('aria-controls');
+    const panel = panels[index] || document.getElementById(panelId);
+    const isSelected = currentTab === tab;
+
+    setInitialState(currentTab, panel, isSelected);
+  });
+
+  tab.focus();
+};
+
+const focusTab = (tabs, index) => {
+  const totalTabs = tabs.length;
+  const nextIndex = (index + totalTabs) % totalTabs;
+
+  tabs.forEach((currentTab, tabIndex) => {
+    currentTab.tabIndex = tabIndex === nextIndex ? 0 : -1;
+  });
+
+  tabs[nextIndex].focus();
+};
+
+export const initTabs = () => {
+  const tabContainers = document.querySelectorAll('.js-tabs');
+
+  tabContainers.forEach((container, containerIndex) => {
+    const tabList = container.querySelector('[role="tablist"]');
+    if (!tabList) return;
+
+    const tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+    if (!tabs.length) return;
+
+    const panels = tabs.map((tab, index) => {
+      if (!tab.id) {
+        tab.id = `js-tab-${containerIndex}-${index}`;
+      }
+
+      const controlsId = tab.getAttribute('aria-controls');
+      return controlsId ? document.getElementById(controlsId) : null;
+    });
+
+    let selectedIndex = tabs.findIndex((tab) => tab.getAttribute('aria-selected') === 'true');
+    if (selectedIndex === -1) {
+      selectedIndex = 0;
+    }
+
+    tabs.forEach((tab, index) => {
+      setInitialState(tab, panels[index], index === selectedIndex);
+
+      tab.addEventListener('click', (event) => {
+        event.preventDefault();
+        activateTab(tab, tabs, panels);
+      });
+
+      tab.addEventListener('keydown', (event) => {
+        const { key } = event;
+        const currentIndex = tabs.indexOf(tab);
+        const orientation = tabList.getAttribute('aria-orientation') || 'horizontal';
+        const isHorizontal = orientation === 'horizontal';
+        const isVertical = orientation === 'vertical';
+
+        if ((isHorizontal && (key === 'ArrowLeft' || key === 'ArrowRight')) ||
+            (isVertical && (key === 'ArrowUp' || key === 'ArrowDown'))) {
+          event.preventDefault();
+          const direction = key === 'ArrowRight' || key === 'ArrowDown' ? 1 : -1;
+          focusTab(tabs, currentIndex + direction);
+        } else if (key === 'Home') {
+          event.preventDefault();
+          focusTab(tabs, 0);
+        } else if (key === 'End') {
+          event.preventDefault();
+          focusTab(tabs, tabs.length - 1);
+        } else if (key === 'Enter' || key === ' ') {
+          event.preventDefault();
+          activateTab(tab, tabs, panels);
+        }
+      });
+    });
+  });
+};

--- a/_src/assets/js/index.js
+++ b/_src/assets/js/index.js
@@ -4,6 +4,7 @@ import { initHeader } from './_header';
 import { inview } from './_inview';
 import { initAccordion } from './_accordion';
 import { matchHeight } from './_matchHeight';
+import { initTabs } from './_tabs';
 
 setVWVH();
 updateMobileClass();
@@ -13,6 +14,7 @@ initHeader();
 inview();
 initAccordion();
 matchHeight('.js-matchHeight', { mode: 'debounce', throttle: 120, leading: true, trailing: true });
+initTabs();
 
 
 

--- a/_src/index.html
+++ b/_src/index.html
@@ -77,6 +77,36 @@
         </div>
       </section>
 
+      <section id="sec-tabs" class="sec-tabs">
+        <h2>DEMO TABS</h2>
+        <div class="c-tabs js-tabs">
+          <div class="c-tabs_tablist" role="tablist" aria-label="Tab ví dụ">
+            <button type="button" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" class="c-tabs_tab is-active">
+              Giới thiệu
+            </button>
+            <button type="button" role="tab" aria-selected="false" aria-controls="tab-panel-2" id="tab-2" class="c-tabs_tab">
+              Tính năng
+            </button>
+            <button type="button" role="tab" aria-selected="false" aria-controls="tab-panel-3" id="tab-3" class="c-tabs_tab">
+              Liên hệ
+            </button>
+          </div>
+          <div id="tab-panel-1" class="c-tabs_panel" role="tabpanel" tabindex="0" aria-labelledby="tab-1">
+            <p>Đây là nội dung giới thiệu cho ví dụ tab. Sử dụng bàn phím để di chuyển giữa các tab.</p>
+          </div>
+          <div id="tab-panel-2" class="c-tabs_panel" role="tabpanel" tabindex="0" aria-labelledby="tab-2" hidden>
+            <ul>
+              <li>Hỗ trợ điều hướng bằng bàn phím với phím mũi tên, Home, End.</li>
+              <li>Tự động cập nhật aria-selected và tabIndex.</li>
+              <li>Ẩn/hiện nội dung bằng thuộc tính <code>hidden</code>.</li>
+            </ul>
+          </div>
+          <div id="tab-panel-3" class="c-tabs_panel" role="tabpanel" tabindex="0" aria-labelledby="tab-3" hidden>
+            <p>Liên hệ với chúng tôi qua email <a href="mailto:info@example.com">info@example.com</a> để biết thêm chi tiết.</p>
+          </div>
+        </div>
+      </section>
+
       <section id="sec02" class="sec02">
         <h2>DEMO MATCH HEIGHT</h2>
         <div class="c-card">


### PR DESCRIPTION
## Summary
- add a WCAG-compliant tabs component with full keyboard interaction support
- register the new tabs component in the global JS bundle and provide demo markup in the main HTML

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4b58f0d4832994dd7484bc4a39f3