### PR TITLE
Improve tab keyboard accessibility

### DIFF
--- a/_src/assets/js/_tabs.js
+++ b/_src/assets/js/_tabs.js
@@ -1,6 +1,6 @@
 const setInitialState = (tab, panel, isSelected) => {
   tab.setAttribute('aria-selected', isSelected ? 'true' : 'false');
-  tab.tabIndex = isSelected ? 0 : -1;
+  tab.tabIndex = 0;
   tab.classList.toggle('is-active', isSelected);
 
   if (panel) {
@@ -32,8 +32,8 @@ const focusTab = (tabs, index) => {
   const totalTabs = tabs.length;
   const nextIndex = (index + totalTabs) % totalTabs;
 
-  tabs.forEach((currentTab, tabIndex) => {
-    currentTab.tabIndex = tabIndex === nextIndex ? 0 : -1;
+  tabs.forEach((currentTab) => {
+    currentTab.tabIndex = 0;
   });
 
   tabs[nextIndex].focus();
@@ -89,6 +89,12 @@ export const initTabs = () => {
         } else if (key === 'End') {
           event.preventDefault();
           focusTab(tabs, tabs.length - 1);
+        } else if (key === 'Tab') {
+          const isSelected = tab.getAttribute('aria-selected') === 'true';
+          if (isSelected) {
+            event.preventDefault();
+            panels[currentIndex]?.focus();
+          }
         } else if (key === 'Enter' || key === ' ') {
           event.preventDefault();
           activateTab(tab, tabs, panels);


### PR DESCRIPTION
## Summary
- keep unselected tabs in the browser's default tab order by leaving their `tabIndex` at 0
- allow pressing Tab on the active tab to focus its associated panel for a logical focus sequence

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5208f75c8329af9272eccc005290